### PR TITLE
Fix input string capitalisation

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,9 @@
 const datafile = require("./data/provinces");
 
 const formatInput = name => {
-  return name ? name.charAt(0).toUpperCase() + name.substring(1) : undefined;
+  return name && name.length > 2
+    ? name.charAt(0).toUpperCase() + name.substring(1).toLowerCase()
+    : undefined;
 };
 
 exports.Provinces = () => {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rwanda",
   "description": "This package provides you access to provinces, districts, sectors, villages and cells found in Rwanda",
-  "version": "1.0.6",
+  "version": "1.0.9",
   "main": "index.js",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
#### What does this PR do?
Fix a small bug when providing the province, strict, etc names without capitalizing them.

#### Description of Task to be completed?
- Checks if the provided name has more than 2 characters
- Capitalize the provided name

#### How should this be manually tested?
- Use any case to retrieve provinces such as `Province("kigali")`

#### Any background context you want to provide?
- It wasn't clear to users on which case to use that introduced bugs into their systems

#### Screenshots (if appropriate)
- N/A