### PR TITLE
fix province capitalization

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ exports.Sectors = () => {
 exports.Sector = (province, district) => {
   if (
     Object.keys(datafile).includes(formatInput(province)) &&
-    Object.keys(datafile[province]).includes(formatInput(district))
+    Object.keys(datafile[formatInput(province)]).includes(formatInput(district))
   ) {
     return Object.keys(datafile[formatInput(province)][formatInput(district)]);
   }


### PR DESCRIPTION
#### What does this PR do?
fix capitalization of province when you call Sector method 
#### Description of Task to be completed?
fix TypeError thrown when user calls Sector with lowercase province input 
#### How should this be manually tested?
try `console.log(Sector("south", "huye"))`
#### Any background context you want to provide?
Whether you pass in lowercase input or uppercase input you should get the results
#### Screenshots (if appropriate)
N/A