### PR TITLE
Handle Case Sensitivity of Inputs with One or Two Words

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,38 @@
 const datafile = require("./data/provinces");
 
-const formatInput = (name) => {
-  return name.replace(/^./, name[0].toUpperCase());
+/**
+ * @param {string}
+ * @returns {string} Capitalized string
+ * @example
+ * 'kiGALi'; // => Kigali
+ */
+const capitalize = (word) => {
+  return word.toLowerCase().replace(/^./, word[0].toUpperCase());
 };
+
+/**
+ * @param {string}
+ * @returns {string} normalized input
+ * @example
+ * 'kiGALi'; // => Kigali
+ * 'RANGO a'; // => Rango A
+ */
+const formatInput = (name) => {
+  let input = name;
+  if (name) {
+    const wordsInName = name.split(" ");
+    if (wordsInName.length === 2) {
+      const firstWord = capitalize(wordsInName[0]);
+      const secondWord = wordsInName[1].toUpperCase();
+      input = firstWord + " " + secondWord;
+    } else if (wordsInName.length === 1) {
+      input = capitalize(name);
+    }
+  }
+
+  return input;
+};
+
 /**
  * @returns {array} province
  * @example

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -174,4 +174,51 @@ describe("Rwanda", async () => {
       expect(villages).to.be.undefined;
     });
   });
+
+  describe("case sensitivity", () => {
+    it("should return villages of nyAKaBAnDA iI", () => {
+      const villages = Villages(
+        "kIGali",
+        "nYaruGenGE",
+        "NYAKABANDA",
+        "nyAKaBAnDA iI"
+      );
+      expect(villages).to.deep.equal([
+        "Ibuhoro",
+        "Kabeza",
+        "Kanyiranganji",
+        "Karujongi",
+        "Kigarama",
+        "Kirwa",
+      ]);
+    });
+
+    it("should return villages of raNgO a", () => {
+      const villages = Villages("sOutH", "hUYE", "muKURA", "raNgO a");
+      expect(villages).to.deep.equal([
+        "Agakera",
+        "Agakombe",
+        "Gaseke",
+        "Kabahora",
+        "Mpaza",
+        "Nyamata",
+        "Rwinuma",
+      ]);
+    });
+
+    it("should return villages of Nyamata y' Umujyi", () => {
+      const villages = Villages(
+        "east",
+        "buGEseRA",
+        "nyamAta",
+        "Nyamata y' Umujyi"
+      );
+      expect(villages).to.have.lengthOf(13);
+    });
+
+    it("should not break with undefined cell", () => {
+      const villages = Villages("east", "buGEseRA", "nyamAta", "");
+      expect(villages).to.be.undefined;
+    });
+  });
 });


### PR DESCRIPTION
#### What does this PR do?
- Fixes the issue of case sensitivity on input with one or two words
#### Description of Task to be completed?
- if a user provides an input of kiGALi, transform it to Kigali, 
- if a user provides an input of rUkiRI ii, transform it to Rukiri II 
- if a user provides an input of ranGo a, transform it to Rango A 
- take the user's input, and normalize it to the shape of the data. 
#### How should this be manually tested?
- Checkout the branch and run it locally 
- Before these changes, calling Districts() with `KIGALI` or `kiGaLi` or different variations of `Kigali` except this one `Kigali` and this one `kigali` would throw an error that it can't return data of undefined or null. 
- Currently, different variations of input works just as imagined. This works if the input has one word or two words.
- 
#### Any background context you want to provide?

I have done an analysis of the data, so far we can narrow down the data to villages of a particular cell. From the analysis I did, I realized the keys in different objects we have, which have more than one word, are these ones: 
```
[
  "Nyamata y' Umujyi", 'Rugarama I',
  'Rugarama II',       'Rukomo II',
  'Rukiri I',          'Rukiri II',
  'Kabuga I',          'Kabuga II',
  'Munanira I',        'Munanira II',
  'Nyakabanda I',      'Nyakabanda II',
  'Kabuguru I',        'Kabuguru II',
  'Rwezamenyo I',      'Rwezamenyo II',
  'Rango A',           'Rango B'
] 

```

Apart from `Nyamata y' Umujyi` which has 3 words, others have two words. The first word is a Capitalized string, and the second word is UPPERCASE of one alphabet or more than one alphabet.  

Therefore, this PR normalizes variations of any input with one or two words to ensure that case insensitivity, which is described on the READme, is handled correctly. 
